### PR TITLE
This commit fixes PHPCS style checks

### DIFF
--- a/src/Concerns/Reauthenticates.php
+++ b/src/Concerns/Reauthenticates.php
@@ -15,7 +15,6 @@ trait Reauthenticates
     {
         //good password
         if (Hash::check($guess, $password)) {
-
             //reset timer
             $this->resetReauthenticationTimer();
 

--- a/src/Concerns/Reauthenticates.php
+++ b/src/Concerns/Reauthenticates.php
@@ -15,6 +15,7 @@ trait Reauthenticates
     {
         //good password
         if (Hash::check($guess, $password)) {
+
             //reset timer
             $this->resetReauthenticationTimer();
 

--- a/src/Reauthenticate.php
+++ b/src/Reauthenticate.php
@@ -18,6 +18,7 @@ class Reauthenticate
     {
         //only check after set number of second
         if ($this->lastAuth($request) > config('reauthenticate.timeout', 3600)) {
+
             //store the requested url
             $request->session()->put('reauthenticate.requested_url', $request->route()->uri());
 

--- a/src/Reauthenticate.php
+++ b/src/Reauthenticate.php
@@ -4,6 +4,11 @@ namespace browner12\reauthenticate;
 
 use Closure;
 
+/**
+ * Class Reauthenticate
+ *
+ * @package browner12\reauthenticate
+ */
 class Reauthenticate
 {
     /**
@@ -11,13 +16,14 @@ class Reauthenticate
      *
      * @param  \Illuminate\Http\Request $request
      * @param  \Closure                 $next
+     *
      * @return mixed
+     * @throws \RuntimeException
      */
     public function handle($request, Closure $next)
     {
         //only check after set number of second
-        if ((strtotime('now') - $request->session()->get('reauthenticate.last_authentication', 0)) > config('reauthenticate.timeout', 3600)) {
-
+        if ($this->lastAuth($request) > config('reauthenticate.timeout', 3600)) {
             //store the requested url
             $request->session()->put('reauthenticate.requested_url', $request->route()->uri());
 
@@ -32,5 +38,16 @@ class Reauthenticate
 
         //next layer
         return $next($request);
+    }
+
+    /**
+     * @param \Illuminate\Http\Request $request
+     *
+     * @return int
+     * @throws \RuntimeException
+     */
+    public function lastAuth($request)
+    {
+        return (time() - $request->session()->get('reauthenticate.last_authentication', 0));
     }
 }

--- a/src/Reauthenticate.php
+++ b/src/Reauthenticate.php
@@ -4,11 +4,6 @@ namespace browner12\reauthenticate;
 
 use Closure;
 
-/**
- * Class Reauthenticate
- *
- * @package browner12\reauthenticate
- */
 class Reauthenticate
 {
     /**
@@ -16,7 +11,6 @@ class Reauthenticate
      *
      * @param  \Illuminate\Http\Request $request
      * @param  \Closure                 $next
-     *
      * @return mixed
      * @throws \RuntimeException
      */
@@ -42,12 +36,11 @@ class Reauthenticate
 
     /**
      * @param \Illuminate\Http\Request $request
-     *
      * @return int
      * @throws \RuntimeException
      */
-    public function lastAuth($request)
+    private function lastAuth($request)
     {
-        return (time() - $request->session()->get('reauthenticate.last_authentication', 0));
+        return time() - $request->session()->get('reauthenticate.last_authentication', 0);
     }
 }


### PR DESCRIPTION
## Description

Refactoring timeout checking to `Reauthenticate::lastAuth()` makes it tad bit cleaner and easier to read (and also got rid of the `Line exceeds 120 characters` warning). Also added some missing docblocks and stuff.

## Motivation and context

To make CI/Travis little happier.

## How has this been tested?

Ran `composer check-style` and got green.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.
